### PR TITLE
Improve error handling when OpenAI API calls fail:

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python3 -m pip install cwhy
 *NOTE*: To use cwhy, you must first set up an OpenAI API key. If you
 already have an API key, you can set it as an environment variable
 called `OPENAI_API_KEY`. If you do not have one yet,
-you can get a key here: https://openai.com/api/.
+you can get a key here: https://platform.openai.com/account/api-keys
 
 ```
 export OPENAI_API_KEY=<your-api-key>
@@ -122,7 +122,7 @@ compute a hash value for an object.
 ### Rust
 
 ```
-% rustc test/testme.rs |& cwhy  
+% rustc test/testme.rs |& cwhy
 There are three issues:  1. There are two unused variables `x` in the
 code.  2. The variable `x` is used after it has already been moved in
 the call to `f(x)`, which takes ownership of `x`. 3. The function


### PR DESCRIPTION
* Don't catch and hide tracebacks for exceptions that aren't OpenAI authentication errors or httpx errors.
* Always print out the exception tracebacks for exceptions we do explicitly handle, so that we always have more context on what went wrong.
* Check for errors from httpx after calling the OpenAI API and before accessing the result; this ensures that authentication/limits issues don't manifest as `KeyError`s when checking the result.
* Handle `httpx.HTTPStatusError`, which is thrown in some cases where you're missing an API key or are above usage/rate limits.
* Add a better link to where you can get an OpenAI key in our diagnostic.
* Add a note about usage/rate limits in our diagnostic.

* Check for errors from httpx after calling the OpenAI API and before accessing the result; this ensures that authentication/limits issues don't manifest as `KeyError`s when checking the result.
* Handle `httpx.HTTPStatusError`, which is thrown in some cases where you're missing an API key or are above usage/rate limits.
* Add a better link to where you can get an OpenAI key in our diagnostic.
* Add a note about usage/rate limits in our diagnostic.

Some examples of what errors look like after this change:

Error if `OPENAI_API_KEY` isn't set or is set to garbage:

```
Traceback (most recent call last):
  File "/home/wash/.local/lib/python3.9/site-packages/cwhy/cwhy.py", line 136, in complete
    completion.raise_for_status()
  File "/usr/local/lib/python3.9/dist-packages/httpx/_models.py", line 749, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '401 Unauthorized' for url 'https://api.openai.com/v1/chat/completions'
For more information check: https://httpstatuses.com/401

You need an OpenAI key to use this tool.
You can get a key here: https://platform.openai.com/account/api-keys
Set the environment variable OPENAI_API_KEY to your key value.
If OPENAI_API_KEY is already correctly set, you may have exceeded your usage or rate limit.
```

If you're rate limited, the error is similar to the above, but is an HTTP 403 error instead.

Error if `OPENAI_API_KEY` is set to empty.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_exceptions.py", line 10, in map_exceptions
    yield
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_async/http11.py", line 121, in _send_request_headers
    event = h11.Request(
  File "/usr/local/lib/python3.9/dist-packages/h11/_events.py", line 96, in __init__
    self, "headers", normalize_and_validate(headers, _parsed=_parsed)
  File "/usr/local/lib/python3.9/dist-packages/h11/_headers.py", line 164, in normalize_and_validate
    validate(_field_value_re, value, "Illegal header value {!r}", value)
  File "/usr/local/lib/python3.9/dist-packages/h11/_util.py", line 91, in validate
    raise LocalProtocolError(msg)
h11._util.LocalProtocolError: Illegal header value b'Bearer '

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.9/dist-packages/httpx/_transports/default.py", line 60, in map_httpcore_exceptions
    yield
  File "/usr/local/lib/python3.9/dist-packages/httpx/_transports/default.py", line 353, in handle_async_request
    resp = await self._pool.handle_async_request(req)
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_async/connection_pool.py", line 253, in handle_async_request
    raise exc
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_async/connection_pool.py", line 237, in handle_async_request
    response = await connection.handle_async_request(request)
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_async/connection.py", line 90, in handle_async_request
    return await self._connection.handle_async_request(request)
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_async/http11.py", line 112, in handle_async_request
    raise exc
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_async/http11.py", line 80, in handle_async_request
    await self._send_request_headers(**kwargs)
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_async/http11.py", line 121, in _send_request_headers
    event = h11.Request(
  File "/usr/lib/python3.9/contextlib.py", line 135, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python3.9/dist-packages/httpcore/_exceptions.py", line 14, in map_exceptions
    raise to_exc(exc)
httpcore.LocalProtocolError: Illegal header value b'Bearer '

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/wash/.local/lib/python3.9/site-packages/cwhy/cwhy.py", line 135, in complete
    completion = await openai_async.chat_complete(openai.api_key, timeout=30, payload={'model': 'gpt-3.5-turbo', 'messages': [{'role': 'user', 'content': user_prompt}]})
  File "/usr/local/lib/python3.9/dist-packages/openai_async/openai_async.py", line 13, in send_to_openai
    return await client.post(
  File "/usr/local/lib/python3.9/dist-packages/httpx/_client.py", line 1848, in post
    return await self.request(
  File "/usr/local/lib/python3.9/dist-packages/httpx/_client.py", line 1533, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/usr/local/lib/python3.9/dist-packages/httpx/_client.py", line 1620, in send
    response = await self._send_handling_auth(
  File "/usr/local/lib/python3.9/dist-packages/httpx/_client.py", line 1648, in _send_handling_auth
    response = await self._send_handling_redirects(
  File "/usr/local/lib/python3.9/dist-packages/httpx/_client.py", line 1685, in _send_handling_redirects
    response = await self._send_single_request(request)
  File "/usr/local/lib/python3.9/dist-packages/httpx/_client.py", line 1722, in _send_single_request
    response = await transport.handle_async_request(request)
  File "/usr/local/lib/python3.9/dist-packages/httpx/_transports/default.py", line 353, in handle_async_request
    resp = await self._pool.handle_async_request(req)
  File "/usr/lib/python3.9/contextlib.py", line 135, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/local/lib/python3.9/dist-packages/httpx/_transports/default.py", line 77, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.LocalProtocolError: Illegal header value b'Bearer '

You need an OpenAI key to use this tool.
You can get a key here: https://platform.openai.com/account/api-keys
Set the environment variable OPENAI_API_KEY to your key value.
If OPENAI_API_KEY is already correctly set, you may have exceeded your usage or rate limit.
```