### PR TITLE
Always use `word_wrap_except_code_blocks` instead of `textwrap`

### DIFF
--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python3
 import asyncio
 import click
-import textwrap
 
 from . import cwhy
 
@@ -13,8 +12,5 @@ def main(fix):
         # Do nothing if nothing was sent to stdin
         return
     text = asyncio.run(cwhy.complete(prompt))
-    if fix:
-        print(cwhy.word_wrap_except_code_blocks(text))
-    else:
-        print('\n'.join(textwrap.wrap(text, width=70)))
+    print(cwhy.word_wrap_except_code_blocks(text))
 


### PR DESCRIPTION
Sometimes the non-fix responses include code blocks that raw `textwrap` mangles, so we should always use `word_wrap_except_code_blocks` instead.

For example, for `test/c++/missing-argument.cpp`:

```
The problem is that the call to `std::transform` in the code is
missing the fourth argument, which is the output iterator. The lambda
function provided is used for the transformation, but there is nowhere
to store the transformed values. The error message indicates that the
expected number of arguments for `std::transform` is either 4 or 5,
depending on whether a binary operation is used.  To fix the error, an
output iterator should be provided as the fourth argument to
`std::transform` to store the transformed values. For example:  ```
#include <algorithm> #include <vector> #include <iterator> // for
std::back_inserter  int main() {     std::vector<int> v {1, 2, 3};
std::vector<int> out;     std::transform(v.begin(), v.end(),
std::back_inserter(out), [](int i) { return i * i; }); } ```  In this
code, the `out` vector is used as the output container for the
transformed values, and `std::back_inserter` is used to create an
output iterator that appends new elements to the end of `out`.
```