### PR TITLE
Support unknown diagnostic contexts better

### DIFF
--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -122,7 +122,7 @@ class context(object):
             line = min(line, 50)
 
         self.unabridged_diagnostic = '\n'.join(diagnostic_lines) + '\n'
-        self.abridged_diagnostic = '```\n' + '\n'.join(diagnostic_lines[0:line]) + '\n```\n'
+        self.abridged_diagnostic = '```\n' + '\n'.join(diagnostic_lines[:line]) + '\n```\n'
 
         def format_code_location(code_location):
             ((file_name, line_start, line_end), abridged_code) = code_location

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -174,7 +174,7 @@ def cwhy_prompt(fix):
         {ctx.abridged_diagnostic}
         """
         if fix:
-            user_prompt = f"""
+            user_prompt += f"""
 
             Suggest code to fix the problem. Surround the code in backticks (```).
             """

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -160,7 +160,7 @@ def cwhy_prompt(fix):
             # Fail silently if stdin was empty
             return ""
 
-        user_prompt = str()
+        user_prompt = ""
         if ctx.code:
             user_prompt += f"""
             This is my code:

--- a/test/python/concatenate-str-to-int.py
+++ b/test/python/concatenate-str-to-int.py
@@ -1,0 +1,6 @@
+#! /usr/bin/env python3
+
+def format(k, v):
+  return k + ' = ' + v
+
+print(format('x', 42))


### PR DESCRIPTION
If we don't recognize the diagnostic we've been given, and thus have no way to extract source locations and find relevant code, we should still try to help by sending the diagnostic to the AI. This PR makes some changes to better support this.