### PR TITLE
Add a new command that extract sources from a diagnostic using AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ export OPENAI_API_KEY=<your-api-key>
 
 ## Usage
 
-Just pipe your compiler's output to `cwhy`. `cwhy` will by default provide an explanation. If you'd like a suggested fix, add `--fix`.
+Just pipe your compiler's output to `cwhy`. `cwhy` will by default provide an explanation. If you'd like a suggested fix, add `fix`.
 
 e.g.,
 
 ```
-% clang++ -g mycode.cpp |& cwhy         # explanation only
-% clang++ -g mycode.cpp |& cwhy --fix   # to see a suggested fix
+% clang++ -g mycode.cpp |& cwhy     # explanation only
+% clang++ -g mycode.cpp |& cwhy fix # to see a suggested fix
 ```
 
 ## Examples
@@ -87,7 +87,7 @@ type.
 And a proposed fix:
 
 ```
-% clang++ test/test.cpp |& cwhy --fix
+% clang++ test/test.cpp |& cwhy fix
 The problem is that `std::hash<Q>` is not defined, so it cannot be
 implicitly instantiated. To fix the issue, define a hash function for
 the `Q` struct. Here's an example:

--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -4,18 +4,40 @@ import click
 
 from . import cwhy
 
-@click.command()
-@click.option('--fix', is_flag=True, help="Instead of explaining error messages, propose a fix.", required=False, default=False)
-@click.option('--show-prompt', is_flag=True, help="Print the prompt before sending it to OpenAI for debugging.", required=False, default=False)
-def main(fix, show_prompt):
-    prompt = cwhy.cwhy_prompt(fix)
+def evaluate_prompt(ctx, prompt, wrap = True):
     if not prompt:
         # Do nothing if nothing was sent to stdin
         return
-    if show_prompt:
+    if ctx.obj['show-prompt']:
         print("===================== Prompt =====================")
         print(prompt)
         print("==================================================")
     text = asyncio.run(cwhy.complete(prompt))
-    print(cwhy.word_wrap_except_code_blocks(text))
+    if wrap: text = cwhy.word_wrap_except_code_blocks(text)
+    print(text)
+
+@click.group(invoke_without_command = True)
+@click.option('--show-prompt', is_flag = True, help = "Print the prompt before sending it to OpenAI for debugging.", required = False, default = False)
+@click.pass_context
+def main(ctx, show_prompt):
+    ctx.ensure_object(dict)
+    ctx.obj['show-prompt'] = show_prompt
+
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(explain)
+
+@main.command(short_help = 'Explain the diagnostic.')
+@click.pass_context
+def explain(ctx):
+    evaluate_prompt(ctx, cwhy.explain_prompt())
+
+@main.command(short_help = 'Propose a fix for the diagnostic.')
+@click.pass_context
+def fix(ctx):
+    evaluate_prompt(ctx, cwhy.fix_prompt())
+
+@main.command(short_help = 'Extract the source locations from the diagnostic as CSV.')
+@click.pass_context
+def extract_sources(ctx):
+    evaluate_prompt(ctx, cwhy.extract_sources_prompt(), wrap = False)
 


### PR DESCRIPTION
This is ground work for an optional mode that uses AI to do identify the source locations / relevant code entities that are in the diagnostic and should be sent to the AI to help it explain and fix the problem. The basic idea is to eventually do this:

0) Give the AI the diagnostic and ask it to identify source locations / relevant code entities.
1) Find and extract those source locations / relevant code entities.
2) Give the AI the diagnostic and the source locations / relevant code entities.

There may need to be an additional step where you ask the AI to classify what programming language / tool are being used, so that you can pick the right extraction mechanisms.

Also, this PR splits the "explain" and "fix" functionality into two different commands, and refactor some common command line code.

With a dirt simple prompt, GPT-3.5 fails to correctly extract all of the source locations. It would often just extract one, or only relative ones. I had to do a bunch of experimentation to find something that works, but it's probably still brittle. I tested it for C++ and Python. GPT-4 is much better at this, even with a dirt simple prompt.

Note that we probably need to start moving away from using python multi-line strings for prompts - they introduce whitespace that is confusing GPT-3.5 in some cases. I ran into this when writing the new prompt.