### PR TITLE
Add compiler wrapper behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,18 @@ variable called `OPENAI_API_KEY`. If you do not have one yet, you can
 ### Compiler wrapper mode
 
 This new mode is recommended as CWhy will then operate in the same context as the compiler, and will do a better job
-finding the right source files. Additional options should be passed along with the `--wrapper` call.
+finding the right source files.
 
 ```bash
 # Invoking the compiler directly.
-% `cwhy --wrapper` mycode.cpp
+% `cwhy wrapper` mycode.cpp
 
 # Invoking with GNU make, using GPT-4.
-% CXX=`cwhy --wrapper --llm gpt-4` make
+% CXX=`cwhy --llm=gpt-4 wrapper` make
 
-# Invoking with CMake.
-% cmake -DCMAKE_CXX_COMPILER=`cwhy --wrapper` ...
+# Invoking with CMake, using GPT-4 and clang++.
+% cmake -DCMAKE_CXX_COMPILER=`cwhy --llm=gpt-4 wrapper --compiler=clang++` ...
 ```
-
-The underlying compiler can be selected with the `CWHY_CXX` environment variable.
 
 ### Original mode
 
@@ -60,6 +58,8 @@ These options can be retrieved with `cwhy --help`.
  -  `--llm`: pick a specific OpenAI LLM. CWhy is tested with `gpt-3.5-turbo` and `gpt-4`.
  -  `--timeout`: pick a different timeout than the default for API calls.
  -  `--show-prompt` (debug): print prompts before calling the API.
+
+The wrapper mode specifically also has a `--compiler` option to select the underlying compiler to use.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cwhy
 
-by [Emery Berger](https://emeryberger.com), [Bryce Adelstein Lelbach](https://twitter.com/blelbach?lang=en), and [Nicolas van Kempen](https://nvankempen.com/)
+by [Emery Berger](https://emeryberger.com), [Bryce Adelstein Lelbach](https://twitter.com/blelbach?lang=en), and
+[Nicolas van Kempen](https://nvankempen.com/).
 
 [![PyPI](https://img.shields.io/pypi/v/cwhy.svg)](https://pypi.org/project/cwhy/)
 [![downloads](https://pepy.tech/badge/cwhy)](https://pepy.tech/project/cwhy)
@@ -16,31 +17,56 @@ Explains and suggests fixes for C/C++/Rust compiler error messages.
 python3 -m pip install cwhy
 ```
 
-*NOTE*: To use cwhy, you must first set up an OpenAI API key. If you
-already have an API key, you can set it as an environment variable
-called `OPENAI_API_KEY`. If you do not have one yet,
-you can get a key here: https://platform.openai.com/account/api-keys
+To use cwhy, you must first set up an OpenAI API key. If you already have an API key, you can set it as an environment
+variable called `OPENAI_API_KEY`. If you do not have one yet, you can
+[get a key here](https://platform.openai.com/account/api-keys).
 
-```
-export OPENAI_API_KEY=<your-api-key>
+```bash
+% export OPENAI_API_KEY=<your-api-key>
 ```
 
 ## Usage
 
-Just pipe your compiler's output to `cwhy`. `cwhy` will by default provide an explanation. If you'd like a suggested fix, add `fix`.
+### Compiler wrapper mode
 
-e.g.,
+This new mode is recommended as CWhy will then operate in the same context as the compiler, and will do a better job
+finding the right source files. Additional options should be passed along with the `--wrapper` call.
 
+```bash
+# Invoking the compiler directly.
+% `cwhy --wrapper` mycode.cpp
+
+# Invoking with GNU make, using GPT-4.
+% CXX=`cwhy --wrapper --llm gpt-4` make
+
+# Invoking with CMake.
+% cmake -DCMAKE_CXX_COMPILER=`cwhy --wrapper` ...
 ```
-% clang++ -g mycode.cpp |& cwhy     # explanation only
-% clang++ -g mycode.cpp |& cwhy fix # to see a suggested fix
+
+The underlying compiler can be selected with the `CWHY_CXX` environment variable.
+
+### Original mode
+
+Just pipe your compiler's output to `cwhy`.
+
+```bash
+% clang++ -g mycode.cpp |& cwhy
 ```
+
+### Options
+
+These options can be retrieved with `cwhy --help`.
+
+ -  `--llm`: pick a specific OpenAI LLM. CWhy is tested with `gpt-3.5-turbo` and `gpt-4`.
+ -  `--timeout`: pick a different timeout than the default for API calls.
+ -  `--show-prompt` (debug): print prompts before calling the API.
 
 ## Examples
 
 ### C++
 
-This highlighted example is [missing-hash.cpp](test/c++/missing-hash.cpp), which is one of the first cases we experimented with.
+This highlighted example is [missing-hash.cpp](test/c++/missing-hash.cpp), which is one of the first cases we
+experimented with.
 
 <details>
 <summary>

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Just pipe your compiler's output to `cwhy`.
 
 ### Options
 
-These options can be retrieved with `cwhy --help`.
+These options can be displayed with `cwhy --help`.
 
- -  `--llm`: pick a specific OpenAI LLM. CWhy is tested with `gpt-3.5-turbo` and `gpt-4`.
+ -  `--llm`: pick a specific OpenAI LLM. CWhy has been tested with `gpt-3.5-turbo` and `gpt-4`.
  -  `--timeout`: pick a different timeout than the default for API calls.
  -  `--show-prompt` (debug): print prompts before calling the API.
 

--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -38,41 +38,10 @@ def main():
         help="print prompts before sending them to OpenAI for debugging",
     )
 
-    subparsers = parser.add_subparsers(title="subcommands", dest="subcommand")
-    subparsers.add_parser(
-        "explain", help="explain the diagnostic. This is the default subcommand"
-    ).set_defaults(fn=explain)
-    subparsers.add_parser("fix", help="propose a fix for the diagnostic").set_defaults(
-        fn=fix
-    )
-    subparsers.add_parser(
-        "extract_sources",
-        help="extract the source locations from the diagnostic as CSV",
-    ).set_defaults(fn=extract_sources)
-
     args = parser.parse_args()
 
     if args.version:
         print(f"cwhy version {importlib.metadata.metadata('cwhy')['Version']}")
         return
 
-    if args.subcommand is None:
-        args.fn = explain
-
-    args.fn(args)
-
-
-def explain(args):
     cwhy.evaluate_prompt(args, cwhy.explain_prompt(sys.stdin.read()))
-
-
-def fix(args):
-    cwhy.evaluate_prompt(args, cwhy.fix_prompt(sys.stdin.read()))
-
-
-def extract_sources(args):
-    cwhy.evaluate_prompt(
-        args,
-        cwhy.extract_sources_prompt(sys.stdin.read()),
-        wrap=False,
-    )

--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -92,6 +92,7 @@ def main():
     if args["subcommand"] == "wrapper":
         with tempfile.NamedTemporaryFile(mode="w", delete=False) as f:
             f.write(wrapper(args))
+        # NamedTemporaryFiles are not executable by default. Set its mode to 755 here with an octal literal.
         os.chmod(f.name, 0o755)
         print(f.name)
     elif args["version"]:

--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -10,30 +10,9 @@ from . import cwhy
 
 
 def wrapper(args):
-    return f"""#! /usr/bin/env python3
-
-import os
-import subprocess
-import sys
-
-from cwhy import cwhy
-
-process = subprocess.run(
-    ["{args["compiler"]}", *sys.argv[1:]],
-    stdout=subprocess.PIPE,
-    stderr=subprocess.STDOUT,
-    text=True,
-)
-status = process.returncode
-if status != 0:
-    print(process.stdout)
-    print("==================================================")
-    print("CWhy")
-    print("==================================================")
-    cwhy.evaluate_prompt({args}, cwhy.explain_prompt(process.stdout))
-    print("==================================================")
-sys.exit(status)
-"""
+    with open(os.path.join(os.path.dirname(__file__), "wrapper.py.in")) as f:
+        template = f.read()
+    return template.format(compiler=args["compiler"], args=args)
 
 
 def main():

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -203,38 +203,3 @@ def base_prompt(diagnostic):
 
 def explain_prompt(diagnostic):
     return base_prompt(diagnostic) + "What's the problem?"
-
-
-def fix_prompt(diagnostic):
-    return (
-        base_prompt(diagnostic)
-        + "Suggest code to fix the problem. Surround the code in backticks (```)."
-    )
-
-
-class extract_sources_context:
-    def __init__(self, diagnostic):
-        diagnostic_lines = diagnostic.splitlines()
-
-        line = min(len(diagnostic_lines) - 1, 50)
-
-        self.unabridged_diagnostic = "\n".join(diagnostic_lines) + "\n"
-        self.abridged_diagnostic = (
-            "```\n" + "\n".join(diagnostic_lines[:line]) + "\n```\n"
-        )
-
-
-def extract_sources_prompt(diagnostic):
-    ctx = extract_sources_context(diagnostic)
-
-    if not ctx.unabridged_diagnostic.strip():
-        # Fail silently if stdin was empty
-        return ""
-
-    user_prompt = "Respond only in the CSV format with no header row.\n"
-    user_prompt += "Identify all of the file paths and associated line numbers.\n"
-    user_prompt += "Output each file path and associated line number.\n"
-    user_prompt += "\n"
-    user_prompt += ctx.abridged_diagnostic
-
-    return user_prompt

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -106,9 +106,6 @@ def complete(args, user_prompt):
 
 
 def evaluate_prompt(args, prompt, wrap=True):
-    if not prompt:
-        # Do nothing if nothing was sent to stdin
-        return
     if args["show_prompt"]:
         print("===================== Prompt =====================")
         print(prompt)
@@ -185,10 +182,6 @@ class explain_context:
 def base_prompt(diagnostic):
     ctx = explain_context(diagnostic)
 
-    if not ctx.unabridged_diagnostic.strip():
-        # Fail silently if stdin was empty
-        return ""
-
     user_prompt = ""
     if ctx.code:
         user_prompt += "This is my code:\n\n"
@@ -203,3 +196,31 @@ def base_prompt(diagnostic):
 
 def explain_prompt(diagnostic):
     return base_prompt(diagnostic) + "What's the problem?"
+
+
+def fix_prompt(diagnostic):
+    return (
+        base_prompt(diagnostic)
+        + "Suggest code to fix the problem. Surround the code in backticks (```)."
+    )
+
+
+class extract_sources_context:
+    def __init__(self, diagnostic):
+        diagnostic_lines = diagnostic.splitlines()
+        line = min(len(diagnostic_lines) - 1, 50)
+        self.unabridged_diagnostic = "\n".join(diagnostic_lines) + "\n"
+        self.abridged_diagnostic = (
+            "```\n" + "\n".join(diagnostic_lines[:line]) + "\n```\n"
+        )
+
+
+def extract_sources_prompt(diagnostic):
+    ctx = extract_sources_context(diagnostic)
+    user_prompt = "Respond only in the CSV format with no header row.\n"
+    user_prompt += "Identify all of the file paths and associated line numbers.\n"
+    user_prompt += "Output each file path and associated line number.\n"
+    user_prompt += "\n"
+    user_prompt += ctx.abridged_diagnostic
+
+    return user_prompt

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -85,8 +85,8 @@ def read_lines(file_path: str, start_line: int, end_line: int) -> (str, int):
 def complete(args, user_prompt):
     try:
         completion = openai.ChatCompletion.create(
-            model=args.llm,
-            request_timeout=args.timeout,
+            model=args["llm"],
+            request_timeout=args["timeout"],
             messages=[{"role": "user", "content": user_prompt}],
         )
         return completion.choices[0].message.content
@@ -109,7 +109,7 @@ def evaluate_prompt(args, prompt, wrap=True):
     if not prompt:
         # Do nothing if nothing was sent to stdin
         return
-    if args.show_prompt:
+    if args["show_prompt"]:
         print("===================== Prompt =====================")
         print(prompt)
         print("==================================================")

--- a/src/cwhy/wrapper.py.in
+++ b/src/cwhy/wrapper.py.in
@@ -1,0 +1,22 @@
+#! /usr/bin/env python3
+
+import subprocess
+import sys
+
+from cwhy import cwhy
+
+process = subprocess.run(
+    ["{compiler}", *sys.argv[1:]],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True,
+)
+status = process.returncode
+if status != 0:
+    print(process.stdout)
+    print("==================================================")
+    print("CWhy")
+    print("==================================================")
+    cwhy.evaluate_prompt({args}, cwhy.explain_prompt(process.stdout))
+    print("==================================================")
+sys.exit(status)


### PR DESCRIPTION
One atomic PR to add compiler wrapper behavior.

This mode is more robust because filenames can properly be resolved from the same working directory as the compiler.

### Issues

 -  A bit more overhead for successful compilation from Python startup time.
 -  Configuration (such as CMake) can be inefficient if checking for things that fail since we will do an API call. Maybe we should add an environment variable check to allow disabling CWhy during configuration.


### How it works

A short script is generated in a temporary file. This allows options to be serialized along with the script and stay consistent across runs. I experimented with a couple other ways to do this but I think this is the best one.