### PR TITLE
Fix #12

### DIFF
--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -141,11 +141,11 @@ class explain_context:
         line = 0
         while line < len(diagnostic_lines):
             # This pattern works for some C++ compilers (GCC, Clang) and Rust.
-            match = re.search(r"^([^:->]+):([0-9]+):([0-9]+)", diagnostic_lines[line])
+            match = re.match(r"([a-zA-Z0-9./][^:->]+):([0-9]+):([0-9]+)", diagnostic_lines[line])
 
             if not match:
                 # This pattern works for javac.
-                match = re.search(r"^([^:->]+):([0-9]+):", diagnostic_lines[line])
+                match = re.match(r"([a-zA-Z0-9./][^:->]+):([0-9]+):", diagnostic_lines[line])
 
             line += 1
 


### PR DESCRIPTION
The Java regex was grepping too much by accident. Here I just make sure the line / path starts with a sensible character (not including whitespace): `[a-zA-Z0-9./]` which should be virtually all paths. Will that still work for Java?