### PR TITLE
Added TypeScript support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ by [Emery Berger](https://emeryberger.com), [Bryce Adelstein Lelbach](https://tw
 
 ("See why")
 
-Explains and suggests fixes for compiler error messages for a range of programming languages, including C, C++, C#, Java, Python, and Rust.
+Explains and suggests fixes for compiler error messages for a range of programming languages, including C, C++, C#, Java, Python, Rust, and TypeScript.
 
 ## Installation
 

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -214,6 +214,10 @@ error_patterns = [
     ("Go", re.compile(
         r"([a-zA-Z0-9./][^:\r\n]+):([0-9]+):([0-9]+): (.*): (.*)"
     )),
+    # TypeScript error message pattern
+    re.compile(
+        r"([a-zA-Z0-9./][^:\r\n]+)\((\d+),(\d+)\): error ([A-Za-z0-9]+): (.*)"
+    ),
 ]
 
 class explain_context:


### PR DESCRIPTION
Note that this does not work if `--pretty` is used, or if `pretty` is set to `True` in a `tsconfig.json` project file.

I tested this with `csrankings.ts` (https://github.com/emeryberger/CSrankings/blob/4eaf0350efb9d95715ef92395f81e7be8b8662a0/csrankings.ts#L256), which I changed to produce a type error:

```diff
-    public static readonly parentMap: { [key: string]: string }
+    public static readonly parentMap: { [key: string]: number }
```

The result from `cwhy`, which is pretty good in that it points to the type error (and a lot better than the 80 lines of errors that look like this):

Original error:

> ```typescript
> csrankings.ts(258,13): error TS2322: Type 'string' is not assignable to type 'number'.
> csrankings.ts(259,13): error TS2322: Type 'string' is not assignable to type 'number'.
> csrankings.ts(260,13): error TS2322: Type 'string' is not assignable to type 'number'.
> csrankings.ts(261,13): error TS2322: Type 'string' is not assignable to type 'number'.
> csrankings.ts(262,13): error TS2322: Type 'string' is not assignable to type 'number'.
> 
> ```
> 

CWhy:

> `% tsc --project tsconfig.json  |& cwhy`            
> The problem is that you are trying to assign a string value to
> variables that are declared as having a number type. The error
> messages are indicating the lines where these type mismatches occur.
> 
> For example, in line 258:
> 
> ```typescript
> 258     'aaai': 'ai',
> ```
> 
> You are assigning the value `'ai'` (a string) to the key `'aaai'` in
> the `parentMap` object, which has a number type. This is causing the
> error.
>  
> To fix this issue, you should ensure that the values assigned to the
> keys in `parentMap` are numbers instead of strings. For example, you
> can modify line 258 to:
> 
> ```typescript
> 258     'aaai': 1,
> ```
> 
> And do the same for all other lines where string values are assigned
> to numerical keys.
> 