### PR TITLE
Changed shebang path to sys.executable

### DIFF
--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -13,7 +13,7 @@ from . import cwhy
 def wrapper(args):
     return textwrap.dedent(
         f"""
-        #! /usr/bin/env python3
+        #! {sys.executable}
         from cwhy import cwhy
         cwhy.wrapper({args})
         """


### PR DESCRIPTION
Changed the hardcoded shebang path to `sys.executable`. This will ensure that the generated wrapper script uses the same Python interpreter and environment (installed packages) as the `cwhy` executable invoked on the command line.

The use case is if you install `cwhy` through something like [pipx](https://pypa.github.io/pipx/), the wrapper script will use the interpreter of _its_ isolated environment. Otherwise, you get an `ModuleNotFoundError: No module named 'cwhy'` error.