### PR TITLE
Fix #25

### DIFF
--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -212,7 +212,7 @@ error_patterns = [
     ),
     # Note: LaTeX must precede Java
     ("LaTeX", re.compile(r"(.*\.tex):(\d+): error: (.*)"), 1, 2),
-    ("Java", re.compile(r"([a-zA-Z0-9./][^:->]+):([0-9]+):"), 1, 2),
+    ("Java", re.compile(r"([a-zA-Z0-9./][^:->]+):([0-9]+): error:"), 1, 2),
     ("Python", re.compile(r'\s*File "(.*?)", line (\d+), in ([^\<].*)'), 1, 2),
     ("Go", re.compile(r"([a-zA-Z0-9./][^:\r\n]+):([0-9]+):([0-9]+): (.*): (.*)"), 1, 2),
     (

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -1,9 +1,9 @@
+import collections
+import os
 import re
+import subprocess
 import sys
 import textwrap
-import os
-import subprocess
-import collections
 from typing import Dict, List, Tuple
 
 import openai
@@ -195,38 +195,38 @@ def evaluate_text_prompt(args, prompt, wrap=True, **kwargs):
 # Define error patterns with associated information. The numbers
 # correspond to the groups matching file name and line number.
 error_patterns = [
-    ("C#", re.compile(
-        r"([a-zA-Z0-9./][^:\r\n]+)\((\d+),(\d+)\): error ([A-Za-z0-9]+): (.*)"
-    ), 1, 2),
-    ("C/C++/Rust", re.compile(
-        r"([a-zA-Z0-9./][^:->]+):([0-9]+):([0-9]+)"
-    ), 1, 2),
-    ("Visual Studio C/C++", re.compile(
-        r"([a-zA-Z]?:?[\\\/a-zA-Z0-9._-]+)\(([0-9]+)\)"
-    ), 1, 2),
+    (
+        "C#",
+        re.compile(
+            r"([a-zA-Z0-9./][^:\r\n]+)\((\d+),(\d+)\): error ([A-Za-z0-9]+): (.*)"
+        ),
+        1,
+        2,
+    ),
+    ("C/C++/Rust", re.compile(r"([a-zA-Z0-9./][^:->]+):([0-9]+):([0-9]+)"), 1, 2),
+    (
+        "Visual Studio C/C++",
+        re.compile(r"([a-zA-Z]?:?[\\\/a-zA-Z0-9._-]+)\(([0-9]+)\)"),
+        1,
+        2,
+    ),
     # Note: LaTeX must precede Java
-    ("LaTeX", re.compile(
-        r"(.*\.tex):(\d+): error: (.*)"
-    ), 1, 2),
-    ("Java", re.compile(
-        r"([a-zA-Z0-9./][^:->]+):([0-9]+):"
-    ), 1, 2),
-    ("Python", re.compile(
-        r'\s*File "(.*?)", line (\d+), in ([^\<].*)'
-    ), 1, 2),
-    ("Go", re.compile(
-        r"([a-zA-Z0-9./][^:\r\n]+):([0-9]+):([0-9]+): (.*): (.*)"
-    ), 1, 2),
-    ("TypeScript", re.compile(
-        r"([a-zA-Z0-9./][^:\r\n]+)\((\d+),(\d+)\): error ([A-Za-z0-9]+): (.*)"
-    ), 1, 2),
-    ("Ruby", re.compile(
-        r'"(.*\.rb)", line (\d+)(?:, in `.*\')?: (.*)'
-    ), 1, 2),
-    ("PHP", re.compile(
-        r"PHP (?:Parse|Fatal) error: (.*) in (.*) on line (\d+)"
-    ), 2, 3),
+    ("LaTeX", re.compile(r"(.*\.tex):(\d+): error: (.*)"), 1, 2),
+    ("Java", re.compile(r"([a-zA-Z0-9./][^:->]+):([0-9]+):"), 1, 2),
+    ("Python", re.compile(r'\s*File "(.*?)", line (\d+), in ([^\<].*)'), 1, 2),
+    ("Go", re.compile(r"([a-zA-Z0-9./][^:\r\n]+):([0-9]+):([0-9]+): (.*): (.*)"), 1, 2),
+    (
+        "TypeScript",
+        re.compile(
+            r"([a-zA-Z0-9./][^:\r\n]+)\((\d+),(\d+)\): error ([A-Za-z0-9]+): (.*)"
+        ),
+        1,
+        2,
+    ),
+    ("Ruby", re.compile(r'"(.*\.rb)", line (\d+)(?:, in `.*\')?: (.*)'), 1, 2),
+    ("PHP", re.compile(r"PHP (?:Parse|Fatal) error: (.*) in (.*) on line (\d+)"), 2, 3),
 ]
+
 
 class explain_context:
     def __init__(self, args, diagnostic):
@@ -238,7 +238,7 @@ class explain_context:
         self.code_locations = collections.defaultdict(dict)
 
         # Go through the diagnostic and build up a list of code locations.
-        for (linenum, line) in enumerate(self.diagnostic_lines):
+        for linenum, line in enumerate(self.diagnostic_lines):
             file_name = None
             line_number = None
             for lang, pattern, file_group, line_group in error_patterns:
@@ -252,13 +252,16 @@ class explain_context:
 
             if not file_name:
                 continue
-            
+
             try:
                 (abridged_code, line_start) = read_lines(
                     file_name, line_number - 7, line_number + 3
                 )
             except FileNotFoundError:
-                print(f"Cwhy warning: file not found: {file_name.lstrip()}")
+                print(
+                    f"Cwhy warning: file not found: {file_name.lstrip()}",
+                    file=sys.stderr,
+                )
                 continue
 
             for i, line_content in enumerate(abridged_code):


### PR DESCRIPTION
This has some formatting changes from the auto-formatter, but the big change is the regex for Java, see fdbbad0176cff17065ca390db42f9efa258f1525. From my tests it looks like Java errors have the word "error" which we can use to be more specific. We don't have any Java tests checked in the repo, @emeryberger could you please test this branch once to make sure it still works on Java and stamp?