### PR TITLE
Add cost estimation on text completion

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name="Nicolas van Kempen", email="nvankemp@gmail.com" },
   { name="Bryce Adelstein Lelbach", email="brycelelbach@gmail.com" }
 ]
-dependencies = ["openai>=0.27.0", "tiktoken>=0.4.0"]
+dependencies = ["openai==0.28.1", "llm_utils==0.1.4"]
 description = "Explains and proposes fixes for compile-time errors for many programming languages."
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name="Nicolas van Kempen", email="nvankemp@gmail.com" },
   { name="Bryce Adelstein Lelbach", email="brycelelbach@gmail.com" }
 ]
-dependencies = ["openai==0.28.1", "llm_utils==0.1.4"]
+dependencies = ["openai==0.28.1", "llm_utils==0.2"]
 description = "Explains and proposes fixes for compile-time errors for many programming languages."
 readme = "README.md"
 requires-python = ">=3.7"
@@ -22,7 +22,6 @@ classifiers = [
 
 [project.scripts]
 cwhy = "cwhy.__main__:main"
-
 
 [project.urls]
 "Homepage" = "https://github.com/plasma-umass/cwhy"

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -103,8 +103,18 @@ def evaluate(args, stdin):
 def evaluate_text_prompt(args, prompt, wrap=True, **kwargs):
     completion = complete(args, prompt, **kwargs)
     text = completion.choices[0].message.content
+
     if wrap:
         text = llm_utils.word_wrap_except_code_blocks(text)
+
+    cost = llm_utils.calculate_cost(
+        completion.usage.prompt_tokens,
+        completion.usage.completion_tokens,
+        args["llm"]
+    )
+    text += "\n\n"
+    text += f"This request cost ~ {cost:.2f}$."
+
     return text
 
 


### PR DESCRIPTION
> **Warning**
> This **depends** on #37. Wish GitHub had some stacked diff capability.

````
% clang++ -std=c++20 tests/c++/missing-hash.cpp |& cwhy --llm gpt-4
The problem is that `std::hash` does not provide a specialization for
`std::pair<int, int>`. This means that you can't use `std::hash` with
`std::pair<int, int>`, hence the error. As a result, when you declare
an `std::unordered_set<std::pair<int, int>>`, the compiler is trying
to create an `std::hash<std::pair<int, int>>`, and failing because it
doesn't exist.

You could define a custom hash function for `std::pair<int, int>` and
use it in your `std::unordered_set`.

Here's an example:

```c++
struct pair_hash {
    template <class T1, class T2>
    std::size_t operator () (const std::pair<T1, T2> &pair) const {
        return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
    }
};

std::unordered_set<std::pair<int, int>, pair_hash> visited;
```

In this code, `pair_hash` is a functor that computes a hash value for
`std::pair<int, int>` objects. This hash function is then used in the
`std::unordered_set` declaration.

This request cost ~ 0.12$.
````