### PR TITLE
Fix broken `python3 -m cwhy`

### DIFF
--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -103,3 +103,6 @@ def main():
         stdin = sys.stdin.read()
         if stdin:
             print(cwhy.evaluate(args, stdin))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #40.

Previously, `python3 -m cwhy` did nothing, while `cwhy` worked.
Now, they both work.
