### PR TITLE
Add new conversation mode: beginning a back-and-forth GPT mode

### DIFF
--- a/src/cwhy/__main__.py
+++ b/src/cwhy/__main__.py
@@ -95,7 +95,10 @@ def main():
 
     subparsers.add_parser("explain", help="Explain the diagnostic. (default)")
     subparsers.add_parser("fix", help="Propose a fix for the diagnostic.")
-    subparsers.add_parser("diff", help="Propose a fix in diff format.")
+    subparsers.add_parser("diff", help="[experimental] Propose a fix in diff format.")
+    subparsers.add_parser(
+        "converse", help="[experimental] A back-and-forth mode with ChatGPT."
+    )
 
     parser.set_defaults(subcommand="explain")
 

--- a/src/cwhy/conversation/__init__.py
+++ b/src/cwhy/conversation/__init__.py
@@ -1,0 +1,52 @@
+import textwrap
+import sys
+
+import openai
+
+from llm_utils import llm_utils
+
+from . import functions
+
+
+def converse(client, args, diagnostic):
+    fns = functions.Functions(args, diagnostic)
+    available_functions_names = [fn["function"]["name"] for fn in fns.as_tools()]
+    system_message = textwrap.dedent(
+        f"""
+            You are an assistant debugger. The user is having an issue with their code, and you are trying to help them.
+            A few functions exist to help with this process, namely: {", ".join(available_functions_names)}.
+            Once you are confident in your answer, explain the diagnostic and possibly provide a way to fix the issue.
+        """
+    ).strip()
+    user_message = f"Here is my error message:\n\n```\n{fns.get_truncated_error_message()}\n```\n\nWhat's the problem?"
+    conversation = [
+        {"role": "system", "content": system_message},
+        {"role": "user", "content": user_message},
+    ]
+
+    while True:
+        completion = client.chat.completions.create(
+            model=args.llm,
+            messages=conversation,
+            tools=fns.as_tools(),
+        )
+
+        choice = completion.choices[0]
+        if choice.finish_reason == "tool_calls":
+            for tool_call in choice.message.tool_calls:
+                function_response = fns.dispatch(tool_call.function)
+                if function_response:
+                    conversation.append(choice.message)
+                    conversation.append(
+                        {
+                            "tool_call_id": tool_call.id,
+                            "role": "tool",
+                            "name": tool_call.function.name,
+                            "content": function_response,
+                        }
+                    )
+        elif choice.finish_reason == "stop":
+            text = completion.choices[0].message.content
+            return llm_utils.word_wrap_except_code_blocks(text)
+        else:
+            print(f"Not found: {choice.finish_reason}.")

--- a/src/cwhy/conversation/functions.py
+++ b/src/cwhy/conversation/functions.py
@@ -1,0 +1,121 @@
+import json
+
+from llm_utils import llm_utils
+
+
+class Functions:
+    def __init__(self, args, diagnostic):
+        self.args = args
+        self.diagnostic = diagnostic
+
+    def as_tools(self):
+        return [
+            {"type": "function", "function": schema}
+            for schema in [
+                # self.get_truncated_error_message_schema(),
+                # self.get_compile_or_run_command_schema(),
+                self.get_code_surrounding_schema(),
+            ]
+        ]
+
+    def dispatch(self, function_call) -> str:
+        arguments = json.loads(function_call.arguments)
+        print(
+            f"Calling: {function_call.name}({', '.join([f'{k}={v}' for k, v in arguments.items()])})"
+        )
+        try:
+            if function_call.name == "get_truncated_error_message":
+                return self.get_truncated_error_message()
+            elif function_call.name == "get_compile_or_run_command":
+                return self.get_compile_or_run_command()
+            elif function_call.name == "get_code_surrounding":
+                return self.get_code_surrounding(
+                    arguments["filename"], arguments["lineno"]
+                )
+        except Exception as e:
+            print(e)
+            pass
+        return None
+
+    def get_truncated_error_message_schema(self):
+        return {
+            "name": "get_truncated_error_message",
+            "description": f"Returns the original error message, truncating to {self.args.max_error_tokens} tokens by keeping the beginning and end of the message.",
+        }
+
+    def get_truncated_error_message(self) -> str:
+        """
+        Alternate taking front and back lines until the maximum number of tokens.
+        """
+        front = []
+        back = []
+        diagnostic_lines = self.diagnostic.splitlines()
+        n = len(diagnostic_lines)
+
+        def build_diagnostic_string():
+            return "\n".join(front) + "\n\n[...]\n\n" + "\n".join(reversed(back)) + "\n"
+
+        for i in range(n):
+            if i % 2 == 0:
+                line = diagnostic_lines[i // 2]
+                list = front
+            else:
+                line = diagnostic_lines[n - i // 2 - 1]
+                list = back
+            list.append(line)
+            count = llm_utils.count_tokens(self.args.llm, build_diagnostic_string())
+            if count > self.args.max_error_tokens:
+                list.pop()
+                break
+        return build_diagnostic_string()
+
+    def get_compile_or_run_command_schema():
+        return {
+            "name": "get_compile_or_run_command",
+            "description": "Returns the command used to compile or run the code.",
+        }
+
+    def get_compile_or_run_command() -> str:
+        # TODO.
+        pass
+
+    def get_code_surrounding_schema(self):
+        return {
+            "name": "get_code_surrounding",
+            "description": "Returns the code in the given file surrounding and including the provided line number.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "description": "The filename to read from.",
+                    },
+                    "lineno": {
+                        "type": "integer",
+                        "description": "The line number to focus on. Some context before and after that line will be provided.",
+                    },
+                },
+                "required": ["filename", "lineno"],
+            },
+        }
+
+    def get_code_surrounding(self, filename: str, lineno: int) -> str:
+        def format_group_code_block(group: list[str], first: int) -> str:
+            while group and not group[0].strip():
+                group = group[1:]
+                first += 1
+            while group and not group[-1].strip():
+                group = group[:-1]
+
+            last = first + len(group) - 1
+            max_line_number_length = len(str(last))
+            result = "\n".join(
+                [
+                    "{0:>{1}} {2}".format(first + i, max_line_number_length, line)
+                    for i, line in enumerate(group)
+                ]
+            )
+            return result
+
+        (lines, first) = llm_utils.read_lines(filename, lineno - 7, lineno + 3)
+        return format_group_code_block(lines, first)

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -6,8 +6,7 @@ import openai
 
 from llm_utils import llm_utils
 
-from . import prompts
-from . import conversation
+from . import conversation, prompts
 
 
 def complete(client, args, user_prompt, **kwargs):
@@ -31,7 +30,7 @@ def complete(client, args, user_prompt, **kwargs):
 
 
 def evaluate_diff(client, args, stdin):
-    prompt = diff_prompt(args, stdin)
+    prompt = prompts.diff_prompt(args, stdin)
     completion = complete(
         client,
         args,

--- a/src/cwhy/cwhy.py
+++ b/src/cwhy/cwhy.py
@@ -1,13 +1,13 @@
 import os
 import subprocess
 import sys
-import textwrap
 
 import openai
 
 from llm_utils import llm_utils
 
-from .prompts import diff_prompt, explain_prompt, fix_prompt
+from . import prompts
+from . import conversation
 
 
 def complete(client, args, user_prompt, **kwargs):
@@ -97,15 +97,17 @@ def evaluate(client, args, stdin):
         return evaluate_with_fallback(client, args, stdin)
 
     if args.subcommand == "explain":
-        return evaluate_text_prompt(client, args, explain_prompt(args, stdin))
+        return evaluate_text_prompt(client, args, prompts.explain_prompt(args, stdin))
     elif args.subcommand == "fix":
-        return evaluate_text_prompt(client, args, fix_prompt(args, stdin))
+        return evaluate_text_prompt(client, args, prompts.fix_prompt(args, stdin))
     elif args.subcommand == "diff":
         return (
             evaluate_diff(client, args, stdin)
             .choices[0]
             .message.function_call.arguments
         )
+    elif args.subcommand == "converse":
+        return conversation.converse(client, args, stdin)
     else:
         raise Exception(f"unknown subcommand: {args.subcommand}")
 
@@ -116,11 +118,11 @@ def main(args, stdin):
         if args.llm == "default":
             args.llm = _DEFAULT_FALLBACK_MODELS[0]
         if args.subcommand == "explain":
-            print(explain_prompt(args, stdin))
+            print(prompts.explain_prompt(args, stdin))
         elif args.subcommand == "fix":
-            print(fix_prompt(args, stdin))
+            print(prompts.fix_prompt(args, stdin))
         elif args.subcommand == "diff":
-            print(diff_prompt(args, stdin))
+            print(prompts.diff_prompt(args, stdin))
         print("==================================================")
         sys.exit(0)
 


### PR DESCRIPTION
This is a start to have a back-and-forth mode with ChatGPT.
The assistant should be able to call functions and ask information to CWhy to provide a better diagnostic.

So far I've only been able to get it to call a single function, example below.
````
% g++ -c tests/c++/push-back-pointer.cpp |& cwhy --llm gpt-4 converse
Calling: get_code_surrounding(filename=tests/c++/push-back-pointer.cpp, lineno=24)
The error says that there's no matching function for call to `push_back(int*&)`,
and it's occurring because you're trying to push an `int*` (integer pointer)
into a `std::vector<int>` (vector of integers). The `push_back` method of
`std::vector` is expecting an `int` (since your vector is of type `int`), but
you're providing an `int*`.

To resolve this issue, you should dereference the pointer when pushing it to the
vector. This way, you're pushing the integer value the pointer is pointing to,
rather than the pointer itself.

Here's the corrected code:

```cpp
#include <vector>

int main() {
    std::vector<int> v;
    int value = 10;
    int* pointer = &value;
    v.push_back(*pointer);
}
```

In this code, `*pointer` dereferences the pointer, meaning it gets the integer
value the pointer is pointing to. The `push_back` method now receives an `int`,
which matches its expected argument type.
````

A single function is provided, `get_compile_or_run_command`, but more can be added. For example, I think the wrapper mode should be default (completely remove non-wrapper mode), and we could then easily provide the compile/run command. The error message (truncated) is passed as the user prompt, we could also provide a way to access more parts of it.

PS: A similar system might be of even bigger interest in ChatDBG.